### PR TITLE
recvNextEvent as DBUS

### DIFF
--- a/src/dbus.cpp
+++ b/src/dbus.cpp
@@ -27,6 +27,7 @@ public Q_SLOTS:
     void raise();
     void sleep();
     void wake();
+    void recvNextEvent();
     /*Q_SIGNALS:
         void psi_pong();
     */
@@ -51,6 +52,9 @@ void PsiConAdapter::raise() { emit ActiveProfiles::instance()->raiseRequested();
 void PsiConAdapter::sleep() { psicon->doSleep(); }
 
 void PsiConAdapter::wake() { psicon->doWakeup(); }
+
+void PsiConAdapter::recvNextEvent() { psicon->recvNextEvent(); }
+
 
 void addPsiConAdapter(PsiCon *psicon)
 {


### PR DESCRIPTION
Добавил возможность дёргать recvNextEvent через Dbus. Актуально в свете того, что глобальные комбинации клавиш не работают. Теперь можно будет открывать пришедшие сообщения дёргая внешний скрипт, запускаемый по комбинации клавиш через окружение рабочего стола