### PR TITLE
psicli: receive next event

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ CMakeLists.txt.user*
 builddir/
 myspell/
 translations/
+compile_commands.json

--- a/src/activeprofiles.h
+++ b/src/activeprofiles.h
@@ -36,6 +36,7 @@ public:
     bool isActive(const QString &profile) const;
     bool isAnyActive() const;
 
+    bool recvNextEvent(const QString &profile) const;
     bool setStatus(const QString &profile, const QString &status, const QString &message) const;
     bool openUri(const QString &profile, const QString &uri) const;
     bool raise(const QString &profile, bool withUI) const;

--- a/src/activeprofiles_dbus.cpp
+++ b/src/activeprofiles_dbus.cpp
@@ -181,6 +181,12 @@ ActiveProfiles::~ActiveProfiles()
     d = nullptr;
 }
 
+bool ActiveProfiles::recvNextEvent(const QString &profile) const
+{
+    QDBusInterface(d->dbusName(profile), "/Main", PSIDBUSMAINIF).call(QDBus::NoBlock, "recvNextEvent");
+    return true;
+}
+
 bool ActiveProfiles::setStatus(const QString &profile, const QString &status, const QString &message) const
 {
     QDBusInterface(d->dbusName(profile), "/Main", PSIDBUSMAINIF).call(QDBus::NoBlock, "setStatus", status, message);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -18,6 +18,9 @@
  */
 
 #include "main.h"
+#include "mainwin.h"
+#include "psievent.h"
+#include <qdbusconnection.h>
 
 #ifdef Q_OS_MAC
 #include "CocoaUtilities/CocoaInitializer.h"
@@ -125,6 +128,9 @@ bool PsiMain::useActiveInstance()
             ActiveProfiles::instance()->setStatus(cmdline.value("profile"), cmdline.value("status"),
                                                   cmdline.value("status-message"));
             raise = false;
+        }
+        if (cmdline.contains("receive-next-event")) {
+            ActiveProfiles::instance()->recvNextEvent(cmdline.value("profile"));
         }
 
         if (raise) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -18,9 +18,6 @@
  */
 
 #include "main.h"
-#include "mainwin.h"
-#include "psievent.h"
-#include <qdbusconnection.h>
 
 #ifdef Q_OS_MAC
 #include "CocoaUtilities/CocoaInitializer.h"

--- a/src/psicli.h
+++ b/src/psicli.h
@@ -19,6 +19,8 @@ public:
                        "(unless used together with --remote).",
                        "do not translate --remote"));
 
+        defineSwitch("receive-next-event", tr("Receive next pending event."));
+
         defineSwitch("remote",
                      tr("Force remote-control mode. "
                         "If there is no running instance, "


### PR DESCRIPTION
A command-line switch option to receive next pending event.